### PR TITLE
Made several modifications to support a unified lint strategy:

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Here's a detailed list of changes/additions that Static Analysis Gradle Plugin m
 
 #### Android Lint
 * Changes the default `abortOnError` flag to false
+* If one does not already exist, this will generate a `lint.xml` file in the project containing the standard rules so we have a common set of checks across all projects.
 
 ### Configuration
 The following configurations can be set in the app `build.gradle` to override the default behaviors:
@@ -81,7 +82,7 @@ staticAnalysis {
     lintAbortOnError        // default:  false
 }
 ```
-<b>Please note that if you want to change lint's `abortOnError` setting that you'll need to do it via this value, since it will overwrite any value you put directly into the `lintOptions` block of your build.gradle file.</b>
+<b>Please note that if you want to change any of the settings referenced here (such as lint's `abortOnError`) you'll need to do it via this configuration block, since this plugin will overwrite any properties you set directly in the `lintOptions`, `findbugs`, or `pmd` block(s) of your build.gradle file.</b>
 
 Refer to the gradle doc for [PmdExtension](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.PmdExtension.html) and [FindBugsExtension](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.FindBugsExtension.html) for an explaination of these fields.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "gradle.plugin.io.intrepid:static-analysis:1.0.1"
+        classpath "gradle.plugin.io.intrepid:static-analysis:1.0.2"
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Here's a detailed list of changes/additions that Static Analysis Gradle Plugin m
 
 #### Android Lint
 * Changes the default `abortOnError` flag to false
-* Sets a default `lintConfig` file
 
 ### Configuration
 The following configurations can be set in the app `build.gradle` to override the default behaviors:
@@ -80,9 +79,10 @@ staticAnalysis {
     findBugsExcludeFilterFile
 
     lintAbortOnError        // default:  false
-    lintConfigFile
 }
 ```
+<b>Please note that if you want to change lint's `abortOnError` setting that you'll need to do it via this value, since it will overwrite any value you put directly into the `lintOptions` block of your build.gradle file.</b>
+
 Refer to the gradle doc for [PmdExtension](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.PmdExtension.html) and [FindBugsExtension](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.quality.FindBugsExtension.html) for an explaination of these fields.
 
 The default `pmdRuleSetFile`, `findBugsExcludeFilterFile`, and `lintConfig` files can be found [here](src/main/resources).

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'io.intrepid'
-version '1.0.1'
+version '1.0.2'
 apply plugin: 'maven'
 
 apply plugin: 'groovy'

--- a/src/main/groovy/io/intrepid/analysis/StaticAnalysis.groovy
+++ b/src/main/groovy/io/intrepid/analysis/StaticAnalysis.groovy
@@ -117,25 +117,27 @@ class StaticAnalysis implements Plugin<Project> {
 
         lintOptions.abortOnError = extension.lintAbortOnError
 
+        // If lint.xml file does not exist, copy it into the module's top-level directory where Android Studio can find it
+        File lintFile = new File(project.projectDir, "lint.xml")
+        if (!lintFile.exists()) {
+            InputStream input = StaticAnalysis.class.getResourceAsStream("/default-lintConfig.xml")
+            lintFile.text = input.text
+        }
+
         List<String> buildVariants = getBuildVariantNames(project)
         for (buildVariant in buildVariants) {
-            configureLintVariant(project, extension, buildVariant, lintOptions)
+            configureLintVariant(project, buildVariant, lintOptions)
         }
 
         // Also setup for the top level "lint" task which runs all variants
-        configureLintVariant(project, extension, "", lintOptions)
+        configureLintVariant(project, "", lintOptions)
     }
 
     private static Task configureLintVariant(Project project,
-                                             StaticAnalysisExtension extension,
                                              String buildVariant,
                                              lintOptions) {
         project.tasks.getByName("lint$buildVariant").doFirst {
-            if (extension.lintConfigFile) {
-                lintOptions.lintConfig = new File(extension.lintConfigFile)
-            } else {
-                lintOptions.lintConfig = copyResourceFileToBuildDir(project, "/default-lintConfig.xml")
-            }
+            lintOptions.lintConfig = new File("lint.xml")
         }
     }
 

--- a/src/main/groovy/io/intrepid/analysis/StaticAnalysisExtension.groovy
+++ b/src/main/groovy/io/intrepid/analysis/StaticAnalysisExtension.groovy
@@ -19,5 +19,4 @@ class StaticAnalysisExtension {
     String findBugsExcludeFilterFile
 
     boolean lintAbortOnError = false
-    String lintConfigFile
 }

--- a/src/main/resources/default-lintConfig.xml
+++ b/src/main/resources/default-lintConfig.xml
@@ -1,146 +1,138 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
     <!-- list of issues to configure -->
+    <!-- The current list of lint checks available: http://tools.android.com/tips/lint-checks -->
 
     <!-- Downgrade severity of not explicitly including all options in switch statements.  (using default does not eliminate this warning) -->
-    <issue id="SwitchIntDef" severity="weak warning"/>
+    <issue id="SwitchIntDef" severity="informational" />
 
     <!-- Upgrade severity of using wrong app compat method - want to highlight cases where this may be occurring. -->
-    <issue id="AppCompatMethod" severity="error"/>
+    <issue id="AppCompatMethod" severity="error" />
 
     <!-- Upgrade severity of not using the Firebase App Indexing API - we may not need this one, as we already have “Missing support for Firebase App Indexing” enabled -->
-    <issue id="GoogleAppIndexingApiWarning" severity="warning"/>
+    <issue id="GoogleAppIndexingApiWarning" severity="warning" />
 
     <!-- Enable checking for app links -->
-    <issue id="AppLinksAutoVerifyError" severity="warning"/>
+    <issue id="AppLinksAutoVerifyError" severity="warning" />
 
     <!-- Enable checking for potential app links -->
-    <issue id="AppLinksAutoVerifyWarning" severity="warning"/>
-
-    <!-- Enable weak checking for UI design back button issues -->
-    <issue id="BackButton" severity="weak warning"/>
+    <issue id="AppLinksAutoVerifyWarning" severity="warning" />
 
     <!-- Upgrade severity of trying to specify AdapterView children in XML -->
-    <issue id="AdapterViewChildren" severity="error"/>
+    <issue id="AdapterViewChildren" severity="error" />
 
     <!-- Upgrade severity of including more than one layout within a ScrollView -->
-    <issue id="ScrollViewCount" severity="error"/>
+    <issue id="ScrollViewCount" severity="error" />
 
     <!-- Enable checking for implied unsupported Chrome OS hardware -->
-    <issue id="PermissionImpliesUnsupportedChromeOsHardware" severity="warning"/>
+    <issue id="PermissionImpliesUnsupportedChromeOsHardware" severity="warning" />
 
     <!-- Enable checking for unsupported Chrome OS hardware -->
-    <issue id="UnsupportedChromeOsHardware" severity="error"/>
+    <issue id="UnsupportedChromeOsHardware" severity="error" />
 
     <!-- Enable checking for insecure cipher mode -->
-    <issue id="GetInstance" severity="error"/>
-
-    <!-- Check for easter eggs -->
-    <issue id="EasterEgg" severity="weak warning"/>
+    <issue id="GetInstance" severity="error" />
 
     <!-- Look for STOPSHIP comments -->
-    <issue id="StopShip" severity="error"/>
+    <issue id="StopShip" severity="error" />
 
     <!-- Look for mangled file line endings -->
-    <issue id="MangledCRLF" severity="weak warning"/>
+    <issue id="MangledCRLF" severity="warning" />
 
     <!-- Increase severity of incorrect Gradle paths -->
-    <issue id="GradlePath" severity="error"/>
+    <issue id="GradlePath" severity="error" />
 
     <!-- Notify of newer library versions -->
-    <issue id="NewerVersionAvailable" severity="info"/>
+    <issue id="NewerVersionAvailable" severity="informational" />
 
     <!-- Enable checking for incorrect icon sizes -->
-    <issue id="IconExpectedSize" severity="warning"/>
+    <issue id="IconExpectedSize" severity="warning" />
 
     <!-- Enable WebP icon conversion suggestion -->
-    <issue id="ConvertToWebp" severity="info"/>
+    <issue id="ConvertToWebp" severity="informational" />
 
     <!-- Upgrade severity of this check to improve layout computation speed -->
-    <issue id="DisableBaselineAlignment" severity="error"/>
+    <issue id="DisableBaselineAlignment" severity="error" />
 
     <!-- Add support for checking for logging calls in production code -->
-    <issue id="LogConditional" severity="weak warning"/>
+    <issue id="LogConditional" severity="informational" />
 
     <!-- Upgrade severity of checking for duplicate features in the manifest -->
-    <issue id="DuplicateUsesFeature" severity="error"/>
+    <issue id="DuplicateUsesFeature" severity="error" />
 
     <!-- Upgrade severity of checking for incorrect attribute definitions -->
-    <issue id="IllegalResourceRef" severity="error"/>
+    <issue id="IllegalResourceRef" severity="error" />
 
     <!-- Upgrade severity of subtle manifest bugs -->
-    <issue id="ManifestOrder" severity="error"/>
+    <issue id="ManifestOrder" severity="error" />
 
     <!-- Upgrade severity of missing minimum and target SDK attributes -->
-    <issue id="UsesMinSdkAttributes" severity="error"/>
-
-    <!-- Enable warning for negative margins -->
-    <issue id="NegativeMargin" severity="weak warning"/>
+    <issue id="UsesMinSdkAttributes" severity="error" />
 
     <!-- Upgrade severity of missing @Keep annotation for animated properties -->
-    <issue id="AnimatorKeep" severity="error"/>
+    <issue id="AnimatorKeep" severity="error" />
 
     <!-- Upgrade severity of missing onClick method referenced from XML -->
-    <issue id="OnClick" severity="error"/>
+    <issue id="OnClick" severity="error" />
 
     <!-- Upgrade severity of exporting PreferenceActivity and exposing application internals -->
-    <issue id="ExportedPreferenceActivity" severity="error"/>
+    <issue id="ExportedPreferenceActivity" severity="error" />
 
     <!-- Upgrade severity of private resource usage -->
-    <issue id="PrivateResource" severity="error"/>
+    <issue id="PrivateResource" severity="error" />
 
     <!-- Downgrade severity of using dp instead of sp for text sizes -->
-    <issue id="SpUsage" severity="weak warning"/>
+    <issue id="SpUsage" severity="informational" />
 
     <!-- Upgrade severity of using mm or in in dimension definitions -->
-    <issue id="InOrMmUsage" severity="error"/>
+    <issue id="InOrMmUsage" severity="error" />
 
     <!-- Downgrade severity of using small text sizes -->
-    <issue id="SmallSp" severity="weak warning"/>
+    <issue id="SmallSp" severity="informational" />
 
     <!-- Upgrade severity of caching RecyclerView positions -->
-    <issue id="RecyclerView" severity="error"/>
+    <issue id="RecyclerView" severity="error" />
 
     <!-- Upgrade severity of classes missing from manifest -->
-    <issue id="Registered" severity="error"/>
+    <issue id="Registered" severity="error" />
 
     <!-- Upgrade severity of incorrect width/height values for ScrollView children -->
-    <issue id="ScrollViewSize" severity="error"/>
+    <issue id="ScrollViewSize" severity="error" />
 
     <!-- Upgrade severity of explicit path references to /sdcard -->
-    <issue id="SdCardPath" severity="error"/>
+    <issue id="SdCardPath" severity="error" />
 
     <!-- Enable checking for insecure random number generation -->
-    <issue id="SecureRandom" severity="weak warning"/>
+    <issue id="SecureRandom" severity="error" />
 
     <!-- Prevent usage of global readable files -->
-    <issue id="SetWorldReadable" severity="error"/>
+    <issue id="SetWorldReadable" severity="error" />
 
     <!-- Prevent usage of global writeable files -->
-    <issue id="SetWorldWritable" severity="error"/>
+    <issue id="SetWorldWritable" severity="error" />
 
     <!-- Downgrade severity of enabling JavaScript -->
-    <issue id="SetJavaScriptEnabled" severity="weak warning"/>
+    <issue id="SetJavaScriptEnabled" severity="informational" />
 
     <!-- Enable checking for invalid usage of methods marked @VisibleForTest -->
-    <issue id="VisibleForTests" severity="warning"/>
+    <issue id="VisibleForTests" severity="warning" />
 
     <!-- Enable suggesting making text selectable -->
-    <issue id="SelectableText" severity="weak warning"/>
+    <issue id="SelectableText" severity="informational" />
 
     <!-- Downgrade severity of typos -->
-    <issue id="Typos" severity="typo"/>
+    <issue id="Typos" severity="informational" />
 
     <!-- Enable checking for smart quotes -->
-    <issue id="TypographyQuotes" severity="weak warning"/>
+    <issue id="TypographyQuotes" severity="informational" />
 
     <!-- Enable checking for unused ids -->
-    <issue id="UnusedIds" severity="info"/>
+    <issue id="UnusedIds" severity="informational" />
 
     <!-- Suppress illegal package error, see https://github.com/square/okio/issues/58 -->
     <issue id="InvalidPackage">
-        <ignore regexp="okio-.*.jar"/>
-        <ignore regexp="retrofit-.*.jar"/>
-	<ignore regexp="requery-.*jar"/>
+        <ignore regexp="okio-.*jar" />
+        <ignore regexp="retrofit-.*jar" />
+        <ignore regexp="requery-.*jar" />
     </issue>
 </lint>


### PR DESCRIPTION
- Updated the lint.xml file to contain the latest changes.
- Modified this script so it will copy the default-lintConfig.xml file to the module's main directory and rename it 'lint.xml' if it did not already exist.  Removed the ability for clients to specify what lint.xml file to use, since in-editor lint checking only works if the file is named lint.xml.
- Added instructions to the README documenting the fact that this plugin will overwrite some settings the user may have specified in the lintOptions section of their build.gradle file.