### PR TITLE
Set GradleDependency lint rule severity to informational

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+Version 1.1.1 *(2018-6-15)*
+----------------------------
+* Changed: Set `GradleDependency` lint rule severity to informational
+
 Version 1.1.0 *(2018-3-23)*
 ----------------------------
 * Changed: Gradle Build Tools has been updated to 3.0.1 and Gradle has been updated to 4.3

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "gradle.plugin.io.intrepid:static-analysis:1.0.3"
+        classpath "gradle.plugin.io.intrepid:static-analysis:1.1.1"
     }
 }
 
@@ -80,7 +80,9 @@ staticAnalysis {
     findBugsClasses         // default:  files("${project.buildDir}/intermediates/classes")
     findBugsExcludeFilterFile
 
-    lintAbortOnError        // default:  false
+    lintAbortOnError        // default:  true
+    lintCheckDependencies   // default:  true
+    lintWarningsAsErrors    // default:  true
 }
 ```
 <b>Please note that if you want to change any of the settings referenced here (such as lint's `abortOnError`) you'll need to do it via this configuration block, since this plugin will overwrite any properties you set directly in the `lintOptions`, `findbugs`, or `pmd` block(s) of your build.gradle file.</b>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'io.intrepid'
-version '1.1.0'
+version '1.1.1'
 apply plugin: 'maven'
 
 apply plugin: 'groovy'

--- a/src/main/resources/default-lintConfig.xml
+++ b/src/main/resources/default-lintConfig.xml
@@ -42,7 +42,10 @@
     <!-- Increase severity of incorrect Gradle paths -->
     <issue id="GradlePath" severity="error" />
 
-    <!-- Notify of newer library versions -->
+    <!-- Notify of newer versions of gradle dependency-->
+    <issue id="GradleDependency" severity="informational" />
+
+    <!-- Similar to GradleDependency, but works with any MavenCentral dependency. This is disabled by default. See the link at the top for more details.-->
     <issue id="NewerVersionAvailable" severity="informational" />
 
     <!-- Enable checking for incorrect icon sizes -->


### PR DESCRIPTION
This was causing builds to fail whenever new versions of library became available