### PR TITLE
Add support for Gradle 5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Change Log
 ==========
+Version 1.2.1 *(2018-12-14)*
+----------------------------
+*  Fixed: Compatibility issues with Gradle 5.0
+
 Version 1.2.0 *(2018-8-10)*
 ----------------------------
 *  Added: `updateLintFile` gradle task to update the project's `lint.xml` to match the library's version. Projects should now specify custom lint rules via `lintOptions` gradle block instead of modifying `lint.xml` so that they don't get overrriden.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath "gradle.plugin.io.intrepid:static-analysis:1.2.0"
+        classpath "gradle.plugin.io.intrepid:static-analysis:1.2.1"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'io.intrepid'
-version '1.2.0'
+version '1.2.1'
 apply plugin: 'maven'
 
 apply plugin: 'groovy'

--- a/src/main/groovy/io/intrepid/analysis/StaticAnalysis.groovy
+++ b/src/main/groovy/io/intrepid/analysis/StaticAnalysis.groovy
@@ -4,7 +4,6 @@ import com.android.build.gradle.AndroidConfig
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.internal.file.collections.SimpleFileCollection
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.plugins.quality.*
 
@@ -50,7 +49,7 @@ class StaticAnalysis implements Plugin<Project> {
                     ruleSetFiles = project.files(extension.pmdRuleSetFile)
                 } else {
                     File file = copyResourceFileToBuildDir(project, "/default-pmd-ruleset.xml")
-                    ruleSetFiles = new SimpleFileCollection(file)
+                    ruleSetFiles = files(file)
                 }
             }
 
@@ -63,12 +62,8 @@ class StaticAnalysis implements Plugin<Project> {
             reports {
                 xml.enabled = true
                 html.enabled = true
-                xml {
-                    destination "$project.buildDir/reports/pmd/pmd.xml"
-                }
-                html {
-                    destination "$project.buildDir/reports/pmd/pmd.html"
-                }
+                xml.destination = new File("$project.buildDir/reports/pmd/pmd.xml")
+                html.destination = new File("$project.buildDir/reports/pmd/pmd.html")
             }
         }
     }
@@ -117,12 +112,8 @@ class StaticAnalysis implements Plugin<Project> {
                         html.enabled = true
                     }
 
-                    xml {
-                        destination "$project.buildDir/reports/findbugs/findbugs.xml"
-                    }
-                    html {
-                        destination "$project.buildDir/reports/findbugs/findbugs.html"
-                    }
+                    xml.destination = new File("$project.buildDir/reports/findbugs/findbugs.xml")
+                    html.destination = new File("$project.buildDir/reports/findbugs/findbugs.html")
                 }
             }
         }


### PR DESCRIPTION
This just replaces the deprecated method calls with the newer version so that it won't fail for projects that are using Gradle 5.0. This library itself is still on 4.x for the time being.